### PR TITLE
docs: add Zensical site config and landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ target/**/*.pdb
 # Contains mutation testing data
 **/mutants.out*/
 
+# Zensical build output
+site/
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,87 @@
+# molpack
+
+Molecular packing in pure Rust, with Python bindings. Part of the
+[molrs](https://github.com/MolCrafts/molrs) toolkit.
+
+molpack builds initial configurations for molecular dynamics: give it a set
+of molecular templates, per-type counts, and geometric restraints (boxes,
+spheres, half-spaces, fixed placements), and it produces non-overlapping
+coordinates that satisfy all constraints.
+
+## Install
+
+=== "CLI"
+
+    ```bash
+    cargo install molcrafts-molpack --features filesystem
+    ```
+
+=== "Rust library"
+
+    ```bash
+    cargo add molcrafts-molpack
+    ```
+
+=== "Python"
+
+    ```bash
+    pip install molcrafts-molpack molcrafts-molrs
+    ```
+
+## Quick start
+
+=== "CLI"
+
+    The `molpack` binary accepts Packmol's `.inp` script format, so it works
+    as a drop-in replacement on the command line. Beyond PDB/XYZ it also
+    reads SDF/MOL, LAMMPS dump, and LAMMPS data.
+
+    ```bash
+    molpack mixture.inp         # file argument
+    molpack < mixture.inp       # stdin
+    cat mixture.inp | molpack   # pipe
+    ```
+
+=== "Rust"
+
+    ```rust
+    use molpack::{InsideBoxRestraint, Molpack, Target};
+
+    let positions = [[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [-0.24, 0.93, 0.0]];
+    let radii = [1.52, 1.20, 1.20];
+
+    let target = Target::from_coords(&positions, &radii, 100)
+        .with_name("water")
+        .with_restraint(InsideBoxRestraint::new([0.0; 3], [40.0; 3]));
+
+    let result = Molpack::new()
+        .tolerance(2.0)
+        .pack(&[target], 200, Some(42))?;
+    ```
+
+=== "Python"
+
+    ```python
+    import molrs
+    from molpack import InsideBox, Molpack, Target
+
+    frame = molrs.read_pdb("water.pdb")
+
+    water = (
+        Target("water", frame, count=100)
+        .with_restraint(InsideBox([0, 0, 0], [40, 40, 40]))
+    )
+    result = Molpack(tolerance=2.0).pack([water], max_loops=200, seed=42)
+    ```
+
+## Where to next
+
+- **[Getting started](getting_started.md)** — full CLI + library walkthrough
+- **[Concepts](concepts.md)** — targets, restraints, the packing loop
+- **[Architecture](architecture.md)** — module map and internals
+- **[Extending](extending.md)** — custom restraints, formats, optimizers
+- **[Packmol parity](packmol_parity.md)** — behavior-alignment notes for users migrating from Packmol
+
+## License
+
+BSD-3-Clause. See [LICENSE](https://github.com/MolCrafts/molpack/blob/master/LICENSE).

--- a/docs/packmol_parity.md
+++ b/docs/packmol_parity.md
@@ -1,4 +1,4 @@
-# molpack Behavior Alignment with Packmol
+# molpack Behavior Parity with Packmol
 
 ## Scope
 - Alignment target: `/Users/roykid/work/packmol` source behavior.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! Reference material (not rustdoc):
 //!
-//! - [Packmol alignment](https://github.com/MolCrafts/molpack/blob/master/docs/packmol_alignment.md)
+//! - [Packmol parity](https://github.com/MolCrafts/molpack/blob/master/docs/packmol_parity.md)
 //!   — kind-number ↔ Rust struct mapping with Fortran pointers.
 //!
 //! ## Quick example

--- a/src/restraint.rs
+++ b/src/restraint.rs
@@ -6,7 +6,7 @@
 //! beside the 14 Packmol-originals in type space.
 //!
 //! Numerical equivalence to the Fortran `comprest.f90` (value) and `gwalls.f90`
-//! (gradient) is preserved branch-for-branch; see `docs/packmol_alignment.md`.
+//! (gradient) is preserved branch-for-branch; see `docs/packmol_parity.md`.
 //!
 //! **Gradient convention**: `Restraint::fg` accumulates INTO `g` with `+=`.
 //! Do not overwrite; many restraints may contribute to the same atom.

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,83 @@
+[project]
+site_name = "molpack"
+site_description = "Packmol-grade molecular packing in pure Rust, with Python bindings."
+site_author = "MolCrafts"
+site_url = "https://molcrafts.github.io/molpack/"
+copyright = "Copyright &copy; 2026 MolCrafts"
+
+nav = [
+  { "Home" = "index.md" },
+  { "Getting started" = "getting_started.md" },
+  { "Concepts" = "concepts.md" },
+  { "Architecture" = "architecture.md" },
+  { "Extending" = "extending.md" },
+  { "Packmol parity" = "packmol_parity.md" },
+]
+
+[project.theme]
+language = "en"
+features = [
+  "announce.dismiss",
+  "content.code.annotate",
+  "content.code.copy",
+  "content.code.select",
+  "content.footnote.tooltips",
+  "content.tabs.link",
+  "content.tooltips",
+  "navigation.footer",
+  "navigation.indexes",
+  "navigation.instant",
+  "navigation.instant.prefetch",
+  "navigation.path",
+  "navigation.sections",
+  "navigation.top",
+  "navigation.tracking",
+  "search.highlight",
+]
+
+[[project.theme.palette]]
+scheme = "default"
+toggle.icon = "lucide/sun"
+toggle.name = "Switch to dark mode"
+
+[[project.theme.palette]]
+scheme = "slate"
+toggle.icon = "lucide/moon"
+toggle.name = "Switch to light mode"
+
+[[project.extra.social]]
+icon = "fontawesome/brands/github"
+link = "https://github.com/MolCrafts/molpack"
+
+[project.markdown_extensions.abbr]
+[project.markdown_extensions.admonition]
+[project.markdown_extensions.attr_list]
+[project.markdown_extensions.def_list]
+[project.markdown_extensions.footnotes]
+[project.markdown_extensions.md_in_html]
+[project.markdown_extensions.toc]
+permalink = true
+[project.markdown_extensions.pymdownx.arithmatex]
+generic = true
+[project.markdown_extensions.pymdownx.betterem]
+[project.markdown_extensions.pymdownx.caret]
+[project.markdown_extensions.pymdownx.details]
+[project.markdown_extensions.pymdownx.highlight]
+anchor_linenums = true
+line_spans = "__span"
+pygments_lang_class = true
+[project.markdown_extensions.pymdownx.inlinehilite]
+[project.markdown_extensions.pymdownx.keys]
+[project.markdown_extensions.pymdownx.magiclink]
+[project.markdown_extensions.pymdownx.mark]
+[project.markdown_extensions.pymdownx.smartsymbols]
+[project.markdown_extensions.pymdownx.superfences]
+custom_fences = [
+  { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" },
+]
+[project.markdown_extensions.pymdownx.tabbed]
+alternate_style = true
+combine_header_slug = true
+[project.markdown_extensions.pymdownx.tasklist]
+custom_checkbox = true
+[project.markdown_extensions.pymdownx.tilde]


### PR DESCRIPTION
## Summary

- Adds `zensical.toml` at repo root configuring the Zensical static-site build (nav, palette, mermaid, common pymdown extensions).
- Adds `docs/index.md` as the landing page; Quick start collapses CLI / Rust / Python into tabs. Packmol is only mentioned in the CLI tab (drop-in `.inp` compatibility).
- Renames `docs/packmol_alignment.md` → `docs/packmol_parity.md` and fixes the two in-tree references (`src/lib.rs`, `src/restraint.rs`).
- Gitignores the Zensical build output directory (`site/`).

No code changes to the packing logic; docs/config only.

## Test plan

- [ ] `zensical build` renders without errors and the nav order is Home → Getting started → Concepts → Architecture → Extending → Packmol parity
- [ ] `cargo doc --no-deps` still succeeds (rustdoc link updated in `src/lib.rs`)
- [ ] `cargo test` stays green
- [ ] No stray references to `packmol_alignment.md` remain (`rg packmol_alignment`)