### PR TITLE
fix(deps): bump molrs-core/molrs-io pin to 0.0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "molcrafts-molrs-core"
-version = "0.0.8"
+version = "0.0.12"
 dependencies = [
  "libm",
  "ndarray",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "molcrafts-molrs-io"
-version = "0.0.8"
+version = "0.0.12"
 dependencies = [
  "flate2",
  "molcrafts-molrs-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ name = "molpack"
 [dependencies]
 # Path deps are for local development; `version` fields are used by
 # `cargo publish` to resolve against the crates.io registry.
-molrs = { path = "../molrs/molrs-core", version = "0.0.8", package = "molcrafts-molrs-core", default-features = false }
-molrs_io = { path = "../molrs/molrs-io", version = "0.0.8", package = "molcrafts-molrs-io" }
+molrs = { path = "../molrs/molrs-core", version = "0.0.12", package = "molcrafts-molrs-core", default-features = false }
+molrs_io = { path = "../molrs/molrs-io", version = "0.0.12", package = "molcrafts-molrs-io" }
 rand = "0.9"
 ndarray = "0.17"
 log = "0.4"


### PR DESCRIPTION
Upstream master pins \`molcrafts-molrs-core = "0.0.8"\`, which no longer exists (crates.io is at 0.0.12, and the neighbouring \`../molrs\` workspace is at 0.0.12). Local dev hid this because cargo honors \`path = \"...\"\` and ignores \`version =\` until publish / fresh-checkout time.

Minimal diff: bump both \`version =\` fields + regenerate \`Cargo.lock\`.

## Test plan
- [ ] CI green (fmt / clippy / test / python bindings)
- [ ] After merge, \`git pull && maturin develop --release\` in \`python/\` installs \`molcrafts-molpack\` locally