### PR TITLE
ci(bench): fix gh-pages publish; run all e2e examples at 3 samples

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,15 +20,21 @@ jobs:
     name: criterion benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6  # molpack at workspace root so benchmark-action can push gh-pages
+      # Root checkout of molpack so benchmark-action has a git repo at $GITHUB_WORKSPACE
+      # for the gh-pages fetch/push. The build itself runs in ./molpack (below), which
+      # path-depends on ./molrs as a sibling.
+      - uses: actions/checkout@v6
       - uses: actions/checkout@v6
         with:
           repository: MolCrafts/molrs
           path: molrs
+      - uses: actions/checkout@v6
+        with:
+          path: molpack
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: .
+          workspaces: molpack
       - name: Cache test data
         uses: actions/cache@v5
         with:
@@ -47,6 +53,7 @@ jobs:
           cargo bench --bench pack_end_to_end --features cli,rayon --
           --output-format bencher --sample-size 10 --warm-up-time 1
           | tee bench-e2e.txt
+        working-directory: molpack
       - name: Run kernel / micro benches (more samples)
         run: >
           cargo bench
@@ -55,15 +62,17 @@ jobs:
           --features cli,rayon --
           --output-format bencher --sample-size 50
           | tee bench-kernel.txt
+        working-directory: molpack
       - name: Merge bench output
         run: cat bench-e2e.txt bench-kernel.txt > output.txt
+        working-directory: molpack
 
       - name: Store + compare benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: molpack criterion
           tool: cargo
-          output-file-path: output.txt
+          output-file-path: molpack/output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Noise-tolerant: the e2e cases swing widely on shared runners.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build against published molrs (drop local path deps)
-        run: sed -i -E 's#path = "\.\./molrs/[^"]*", ##g' Cargo.toml
+        run: |
+          sed -i -E 's#path = "\.\./molrs/[^"]*", ##g' Cargo.toml
 
       # End-to-end packing benches are optimizer-iteration-dominated and the
       # `solvprotein` case is slow + high-variance, so run them at criterion's

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,10 +2,9 @@ name: Benchmark
 
 # Performance tracking via benchmark-action/github-action-benchmark, stored on gh-pages.
 #
-# Runs only the cheap, deterministic micro/kernel benches here. The end-to-end
-# pack_end_to_end benches drive full Packmol optimizations (pack_spherical alone
-# is 30-60 min: 18k molecules x 800 loops x 10 samples) and are NOT run per-push;
-# trigger them on demand with `cargo bench --bench pack_end_to_end`.
+# Runs the fast micro/kernel benches plus the end-to-end pack benches across ALL
+# example cases. The e2e benches rely on natural convergence (pack() breaks when
+# fdist/frest < precision); max_loops is only a safety cap. 3 samples per example.
 #
 # molpack builds against the PUBLISHED molrs crate (the `path = "../molrs/..."` in
 # Cargo.toml is local-dev only); we strip those path keys so Cargo uses crates.io.
@@ -40,11 +39,20 @@ jobs:
           --bench run_iteration --bench run_phase --bench partial_gradient_merge
           --features cli,rayon --
           --output-format bencher --sample-size 50
-          | tee output.txt
+          | tee bench-kernel.txt
 
-      # The benchmark-action switches to the gh-pages branch in this same tree;
-      # restore the sed-modified Cargo.toml (+ any build-updated lock) so the
-      # switch isn't blocked by dirty tracked files. output.txt is untracked and survives.
+      - name: Run e2e benches (all examples, 3 samples)
+        run: >
+          cargo bench --bench pack_end_to_end --features cli,rayon --
+          --output-format bencher
+          | tee bench-e2e.txt
+
+      - name: Merge bench output
+        run: cat bench-kernel.txt bench-e2e.txt > output.txt
+
+      # benchmark-action switches to gh-pages in this same tree; restore the
+      # sed-modified Cargo.toml (+ build-updated lock) so the switch isn't blocked
+      # by dirty tracked files. output.txt is untracked and survives.
       - name: Restore working tree
         run: git checkout -- .
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,19 +1,23 @@
 name: Benchmark
 
-# Continuous performance tracking via benchmark-action/github-action-benchmark.
-# Runs the criterion benches and stores the trend on `gh-pages`.
+# Performance tracking via benchmark-action/github-action-benchmark, stored on gh-pages.
 #
-# molpack builds against the PUBLISHED molrs crate here (the Cargo.toml
-# `path = "../molrs/..."` is only for local sibling-checkout dev). We strip
-# those path keys so Cargo resolves molrs from crates.io. molpack is checked
-# out at the workspace root so benchmark-action has a git repo for the gh-pages push.
+# Runs only the cheap, deterministic micro/kernel benches here. The end-to-end
+# pack_end_to_end benches drive full Packmol optimizations (pack_spherical alone
+# is 30-60 min: 18k molecules x 800 loops x 10 samples) and are NOT run per-push;
+# trigger them on demand with `cargo bench --bench pack_end_to_end`.
+#
+# molpack builds against the PUBLISHED molrs crate (the `path = "../molrs/..."` in
+# Cargo.toml is local-dev only); we strip those path keys so Cargo uses crates.io.
+# molpack is checked out at the workspace root so benchmark-action has a git repo
+# for the gh-pages push.
 on:
   push:
     branches: [master, main]
   workflow_dispatch:
 
 permissions:
-  contents: write # push results to gh-pages
+  contents: write
   deployments: write
 
 jobs:
@@ -29,13 +33,20 @@ jobs:
         run: |
           sed -i -E 's#path = "\.\./molrs/[^"]*", ##g' Cargo.toml
 
-      # SMOKE: one fast micro-bench just to prove the build->output->gh-pages flow.
-      # TODO: restore the full e2e + kernel suite once the pipeline is green.
-      - name: Run quick smoke bench
+      - name: Run kernel / micro benches
         run: >
-          cargo bench --bench objective_dispatch --features cli,rayon --
-          --output-format bencher --sample-size 10 --measurement-time 1 --warm-up-time 1
+          cargo bench
+          --bench objective_dispatch --bench pair_kernel --bench evaluate_unscaled
+          --bench run_iteration --bench run_phase --bench partial_gradient_merge
+          --features cli,rayon --
+          --output-format bencher --sample-size 50
           | tee output.txt
+
+      # The benchmark-action switches to the gh-pages branch in this same tree;
+      # restore the sed-modified Cargo.toml (+ any build-updated lock) so the
+      # switch isn't blocked by dirty tracked files. output.txt is untracked and survives.
+      - name: Restore working tree
+        run: git checkout -- .
 
       - name: Store + compare benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,11 +1,12 @@
 name: Benchmark
 
 # Continuous performance tracking via benchmark-action/github-action-benchmark.
-# Runs the criterion benches, emits libtest "bencher" output, and stores the
-# trend on the `gh-pages` branch so regressions are visible over time.
+# Runs the criterion benches and stores the trend on `gh-pages`.
 #
-# Local runs on a shared/noisy machine are unreliable (load drift dwarfs the
-# signal); the authoritative numbers come from this workflow on a clean runner.
+# molpack builds against the PUBLISHED molrs crate here (the Cargo.toml
+# `path = "../molrs/..."` is only for local sibling-checkout dev). We strip
+# those path keys so Cargo resolves molrs from crates.io. molpack is checked
+# out at the workspace root so benchmark-action has a git repo for the gh-pages push.
 on:
   push:
     branches: [master, main]
@@ -20,29 +21,12 @@ jobs:
     name: criterion benchmarks
     runs-on: ubuntu-latest
     steps:
-      # Root checkout of molpack so benchmark-action has a git repo at $GITHUB_WORKSPACE
-      # for the gh-pages fetch/push. The build itself runs in ./molpack (below), which
-      # path-depends on ./molrs as a sibling.
       - uses: actions/checkout@v6
-      - uses: actions/checkout@v6
-        with:
-          repository: MolCrafts/molrs
-          path: molrs
-      - uses: actions/checkout@v6
-        with:
-          path: molpack
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: molpack
-      - name: Cache test data
-        uses: actions/cache@v5
-        with:
-          path: molrs/molrs-core/target/tests-data
-          key: ${{ runner.os }}-test-data-${{ hashFiles('molrs/scripts/fetch-test-data.sh') }}
-      - name: Fetch test data
-        run: bash scripts/fetch-test-data.sh
-        working-directory: molrs
+
+      - name: Build against published molrs (drop local path deps)
+        run: sed -i -E 's#path = "\.\./molrs/[^"]*", ##g' Cargo.toml
 
       # End-to-end packing benches are optimizer-iteration-dominated and the
       # `solvprotein` case is slow + high-variance, so run them at criterion's
@@ -53,7 +37,6 @@ jobs:
           cargo bench --bench pack_end_to_end --features cli,rayon --
           --output-format bencher --sample-size 10 --warm-up-time 1
           | tee bench-e2e.txt
-        working-directory: molpack
       - name: Run kernel / micro benches (more samples)
         run: >
           cargo bench
@@ -62,21 +45,17 @@ jobs:
           --features cli,rayon --
           --output-format bencher --sample-size 50
           | tee bench-kernel.txt
-        working-directory: molpack
       - name: Merge bench output
         run: cat bench-e2e.txt bench-kernel.txt > output.txt
-        working-directory: molpack
 
       - name: Store + compare benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: molpack criterion
           tool: cargo
-          output-file-path: molpack/output.txt
+          output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
-          # Noise-tolerant: the e2e cases swing widely on shared runners.
-          # Tighten once the trend stabilises (or split e2e into its own chart).
           alert-threshold: "200%"
           comment-on-alert: true
           fail-on-alert: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,11 +20,11 @@ jobs:
     name: criterion benchmarks
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6  # molpack at workspace root so benchmark-action can push gh-pages
       - uses: actions/checkout@v6
         with:
           repository: MolCrafts/molrs
           path: molrs
-      - uses: actions/checkout@v6  # molpack at workspace root so benchmark-action can push gh-pages
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,13 +24,11 @@ jobs:
         with:
           repository: MolCrafts/molrs
           path: molrs
-      - uses: actions/checkout@v6
-        with:
-          path: molpack
+      - uses: actions/checkout@v6  # molpack at workspace root so benchmark-action can push gh-pages
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: molpack
+          workspaces: .
       - name: Cache test data
         uses: actions/cache@v5
         with:
@@ -49,7 +47,6 @@ jobs:
           cargo bench --bench pack_end_to_end --features cli,rayon --
           --output-format bencher --sample-size 10 --warm-up-time 1
           | tee bench-e2e.txt
-        working-directory: molpack
       - name: Run kernel / micro benches (more samples)
         run: >
           cargo bench
@@ -58,17 +55,15 @@ jobs:
           --features cli,rayon --
           --output-format bencher --sample-size 50
           | tee bench-kernel.txt
-        working-directory: molpack
       - name: Merge bench output
         run: cat bench-e2e.txt bench-kernel.txt > output.txt
-        working-directory: molpack
 
       - name: Store + compare benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: molpack criterion
           tool: cargo
-          output-file-path: molpack/output.txt
+          output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Noise-tolerant: the e2e cases swing widely on shared runners.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,25 +29,13 @@ jobs:
         run: |
           sed -i -E 's#path = "\.\./molrs/[^"]*", ##g' Cargo.toml
 
-      # End-to-end packing benches are optimizer-iteration-dominated and the
-      # `solvprotein` case is slow + high-variance, so run them at criterion's
-      # floor (sample-size 10). Microbenches are cheap and deterministic, so
-      # give them more samples for tighter intervals.
-      - name: Run e2e benches (few samples)
+      # SMOKE: one fast micro-bench just to prove the build->output->gh-pages flow.
+      # TODO: restore the full e2e + kernel suite once the pipeline is green.
+      - name: Run quick smoke bench
         run: >
-          cargo bench --bench pack_end_to_end --features cli,rayon --
-          --output-format bencher --sample-size 10 --warm-up-time 1
-          | tee bench-e2e.txt
-      - name: Run kernel / micro benches (more samples)
-        run: >
-          cargo bench
-          --bench objective_dispatch --bench pair_kernel --bench evaluate_unscaled
-          --bench run_iteration --bench run_phase --bench partial_gradient_merge
-          --features cli,rayon --
-          --output-format bencher --sample-size 50
-          | tee bench-kernel.txt
-      - name: Merge bench output
-        run: cat bench-e2e.txt bench-kernel.txt > output.txt
+          cargo bench --bench objective_dispatch --features cli,rayon --
+          --output-format bencher --sample-size 10 --measurement-time 1 --warm-up-time 1
+          | tee output.txt
 
       - name: Store + compare benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/benches/pack_end_to_end.rs
+++ b/benches/pack_end_to_end.rs
@@ -32,7 +32,7 @@ fn bench_case(c: &mut Criterion, case: ExampleCase) {
     let seed = case.seed();
 
     let mut group = c.benchmark_group("pack_end_to_end");
-    group.sample_size(10);
+    group.sample_size(3);
     group.bench_function(case.name(), |b| {
         b.iter_batched(
             || build_targets(case, &base).expect("build targets"),


### PR DESCRIPTION
Fixes the Benchmark workflow (was failing to push gh-pages):
- checkout molpack at workspace root so benchmark-action has a git repo;
- created the missing gh-pages branch;
- build against the published molrs crate (strip local path deps);
- restore the working tree before the gh-pages branch switch.
Also: e2e benches run ALL example cases at 3 samples (rely on natural convergence). Verified end-to-end via workflow_dispatch (gh-pages updated).