### PR TITLE
ci: fix bench gh-pages publish + unify release on v* tag

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write      # push results to the gh-pages dashboard
+  contents: write      # push results to the gh-pages history
   deployments: write   # github-action-benchmark uses deployment status
 
 jobs:
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 30
     steps:
       # molpack path-depends on ../molrs/molrs, so both repos are checked out
-      # side by side (matching ci.yml).
+      # side by side (matching ci.yml) — hence molpack lives in a subdir.
       - uses: actions/checkout@v6
         with:
           repository: MolCrafts/molrs
@@ -47,20 +47,36 @@ jobs:
           cargo bench --benches -- --output-format bencher | tee output.txt
         working-directory: molpack
 
-      - name: Upload raw bench output
-        if: always()
+      - name: Upload bench output
         uses: actions/upload-artifact@v4
         with:
-          name: molpack-bench-${{ github.run_id }}
+          name: bench-output
           path: molpack/output.txt
           if-no-files-found: error
 
+  # Separate job so the benchmark action runs against a molpack checkout at the
+  # workspace ROOT — it does `git fetch gh-pages`, which needs a `.git` in the
+  # working directory. The build job puts molpack in a subdir (for the molrs
+  # path-dep), leaving the root without a repo; this job only needs the repo +
+  # the bench output, not molrs, so it checks molpack out at the root.
+  publish-history:
+    name: publish benchmark history
+    needs: bench
+    if: github.repository == 'MolCrafts/molpack' && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      deployments: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          name: bench-output
       - name: Publish benchmark history
-        if: github.repository == 'MolCrafts/molpack' && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: 'cargo'
-          output-file-path: molpack/output.txt
+          output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Criterion on shared runners is noisy — alert loudly, do not fail.

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -25,12 +25,27 @@ jobs:
         with:
           path: molpack
       - uses: dtolnay/rust-toolchain@stable
+      # Idempotent: skip publishing if this exact version is already on
+      # crates.io (bootstrapped manually, or the tag was re-pushed). Both the
+      # crate and PyPI publish now fire on the same `v*` tag, so this keeps the
+      # crate job green when only the wheel needs (re)publishing.
+      - id: exists
+        name: Check if the crate version is already published
+        working-directory: molpack
+        run: |
+          ver=$(sed -nE 's/^version = "(.*)"/\1/p' Cargo.toml | head -1)
+          code=$(curl -s -o /dev/null -w '%{http_code}' -A 'molpack-release-ci' "https://crates.io/api/v1/crates/molcrafts-molpack/$ver")
+          echo "molcrafts-molpack $ver -> HTTP $code"
+          if [ "$code" = "200" ]; then echo "published=true" >> "$GITHUB_OUTPUT"; else echo "published=false" >> "$GITHUB_OUTPUT"; fi
       - name: cargo publish --dry-run
+        if: steps.exists.outputs.published != 'true'
         run: cargo publish --dry-run
         working-directory: molpack
       - id: auth
+        if: steps.exists.outputs.published != 'true'
         uses: rust-lang/crates-io-auth-action@v1
       - name: cargo publish
+        if: steps.exists.outputs.published != 'true'
         run: cargo publish
         working-directory: molpack
         env:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,7 +3,7 @@ name: Publish molcrafts-molpack to PyPI
 on:
   push:
     tags:
-      - "py-v*"
+      - "v*"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Fixes the two red workflows after the v0.1.0 merge:
- **bench**: split the history-push into its own job with a root molpack checkout so github-action-benchmark has a `.git` to fetch gh-pages into.
- **release tags**: unify on `v*` — publish-pypi triggers on `v*` (was `py-v*`), and publish-crate skips when the version is already on crates.io, so one `v0.1.0` tag cleanly drives both without red-failing the already-bootstrapped crate.
- Docs Pages deploy already fixed by switching Pages source to GitHub Actions.