### PR TITLE
chore(release): 0.1.1 (molrs/molpy 0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `molcrafts-molpack` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-07-08
+
+### Changed
+- Bumped the `molcrafts-molrs` dependency (Rust crate + `molrs-ffi` FFI layer and
+  the Python runtime pins) from 0.6.0 to 0.7.0, and the Python runtime
+  `molcrafts-molpy` pin from 0.6.0 to 0.7.0. No molpack API change — a
+  dependency-tracking release against the unified molrs/molpy 0.7.0 line.
+- Docs build now pins the shared `molcrafts-zensical-theme` at 0.1.1.
+
 ## [0.1.0] - 2026-07-04
 
 Inaugural release of `molcrafts-molpack`.
@@ -69,4 +78,5 @@ Inaugural release of `molcrafts-molpack`.
 - CI runs the test suites plus the Packmol regression (on non-PR events); formatting and lint (`fmt`, `clippy`, `ruff`, `ty`) are enforced by pre-commit hooks.
 - Depends on the unified `molcrafts-molrs` 0.6.0 crate: `core` is always-on and re-exported at the crate root, while `io` and `ff` are feature-gated modules that forward to `molrs/io` and `molrs/ff`.
 
+[0.1.1]: https://github.com/MolCrafts/molpack/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/MolCrafts/molpack/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molcrafts-molpack"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.91"
 authors = ["MolCrafts"]
@@ -28,7 +28,7 @@ bench = false
 # Library-required. The merged `molcrafts-molrs` crate exposes its former member
 # crates as feature-gated modules: `core` is always on (re-exported at the crate
 # root), while `io` and `ff` are opt-in via the molpack features below.
-molrs = { path = "../molrs/molrs", version = "0.6.0", package = "molcrafts-molrs", default-features = false }
+molrs = { path = "../molrs/molrs", version = "0.7.0", package = "molcrafts-molrs", default-features = false }
 rand = "0.9"
 ndarray = "0.17"
 log = "0.4"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molpack-python"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.91"
 authors = ["MolCrafts"]
@@ -17,17 +17,17 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.28", features = ["extension-module"] }
 numpy = "0.28"
 ndarray = "0.17"
-molpack = { path = "..", package = "molcrafts-molpack", version = "0.1.0" }
+molpack = { path = "..", package = "molcrafts-molpack", version = "0.1.1" }
 # Same crate (and version) molpack links, so frame types unify across the wheel.
 # The merged `molcrafts-molrs` crate exposes core at its root with default
 # features off (matching molpack's dependency), so the wheel stays io/ff-free.
-molrs = { path = "../../molrs/molrs", package = "molcrafts-molrs", version = "0.6.0", default-features = false }
+molrs = { path = "../../molrs/molrs", package = "molcrafts-molrs", version = "0.7.0", default-features = false }
 # Stable FFI handle layer. molpack resolves molrs/molpy Python objects to
 # `molrs_ffi::{FrameRef, ForceFieldRef}` capsules (zero-copy) instead of dict
-# marshalling — see `src/interop.rs`. Pinned to the same 0.6.0 molrs-python
+# marshalling — see `src/interop.rs`. Pinned to the same 0.7.0 molrs-python
 # links, so the handle types and the `molrs::Frame` they lend share one layout
 # (path+version managed manually, per project convention).
-molrs-ffi = { path = "../../molrs/molrs-ffi", package = "molcrafts-molrs-ffi", version = "0.6.0" }
+molrs-ffi = { path = "../../molrs/molrs-ffi", package = "molcrafts-molrs-ffi", version = "0.7.0" }
 # Direct rayon dep so the binding can introspect/configure the global pool
 # (`num_threads`, `init_thread_pool`); shares the same process-global pool
 # molpack's parallel evaluator runs on. Gated behind the `rayon` feature.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,6 +11,17 @@ readme = "README.md"
 license = "BSD-3-Clause"
 dependencies = ["numpy>=2.0", "typer>=0.12", "molcrafts-molrs>=0.6.0", "molcrafts-molpy>=0.6.0"]
 
+# Installable "extra" carrying the docs-build deps. Unlike the [dependency-groups]
+# doc group below (dev/CI-only, installs deps but not the package), an extra ships
+# in the wheel metadata, so a *prebuilt-wheel* install pulls it with no Rust build:
+#   pip install "molcrafts-molpack[doc]"
+# That is the build command a Cloudflare Pages Git-integration build should use.
+[project.optional-dependencies]
+doc = [
+  "zensical>=0.0.45",
+  "molcrafts-zensical-theme>=0.1.1",
+]
+
 # PEP 735 dependency groups — the single source of truth for dev-time
 # deps used by both CI jobs and local pre-commit hooks.
 #
@@ -44,7 +55,7 @@ dev = [
 doc = [
   "zensical>=0.0.45",
   # The molcrafts docs theme (zensical.toml sets `theme.name = "molcrafts"`).
-  "molcrafts-zensical-theme>=0.1.0",
+  "molcrafts-zensical-theme>=0.1.1",
 ]
 
 [project.scripts]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "maturin"
 
 [project]
 name = "molcrafts-molpack"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python bindings for molpack molecular packing (Packmol port)"
 requires-python = ">=3.12"
 readme = "README.md"
 license = "BSD-3-Clause"
-dependencies = ["numpy>=2.0", "typer>=0.12", "molcrafts-molrs>=0.6.0", "molcrafts-molpy>=0.6.0"]
+dependencies = ["numpy>=2.0", "typer>=0.12", "molcrafts-molrs>=0.7.0", "molcrafts-molpy>=0.7.0"]
 
 # Installable "extra" carrying the docs-build deps. Unlike the [dependency-groups]
 # doc group below (dev/CI-only, installs deps but not the package), an extra ships
@@ -32,7 +32,7 @@ typecheck = [
   "ty",
   "typer>=0.12",
   "numpy>=2.0",
-  "molcrafts-molrs>=0.6.0",
+  "molcrafts-molrs>=0.7.0",
   # `ty check` walks tests/ which imports pytest.
   "pytest",
 ]
@@ -40,7 +40,7 @@ test = [
   "pytest",
   "typer>=0.12",
   "numpy>=2.0",
-  "molcrafts-molrs>=0.6.0",
+  "molcrafts-molrs>=0.7.0",
 ]
 dev = [
   {include-group = "typecheck"},


### PR DESCRIPTION
## Summary

Dependency-tracking patch release of \`molcrafts-molpack\` against the unified **molrs / molpy 0.7.0** line. No molpack API change.

- Bump \`molcrafts-molrs\` (Rust crate + \`molrs-ffi\` FFI layer + Python runtime pins) 0.6.0 → **0.7.0**
- Bump \`molcrafts-molpy\` Python runtime pin 0.6.0 → **0.7.0**
- \`molcrafts-molpack\` 0.1.0 → **0.1.1** (Rust crate + \`molpack-python\` + wheel)
- Docs build pins the shared \`molcrafts-zensical-theme\` at **0.1.1** (carries the earlier theme-bump commit)

## Verification (local, molrs/molrs-ffi/molpy all 0.7.0)

- \`cargo build --features cli,ff,rayon\` — clean
- \`cargo test --features cli,ff,rayon --lib --tests\` — all green (0 failures)
- \`cargo clippy --all-targets --all-features -- -D warnings\` — clean; \`cargo fmt --check\` — clean
- \`maturin develop --release\` — wheel built as 0.1.1
- \`pytest\` — 153 passed
- \`ty check\` — passed

## Release

After merge, tag \`v0.1.1\` on master fires \`publish-crate.yml\` (crates.io) + \`publish-pypi.yml\` (PyPI) on the same tag. All deps are already live: molrs 0.7.0 (crates.io + PyPI), molpy 0.7.0 (PyPI).